### PR TITLE
Wargroove 2: Add item groups.

### DIFF
--- a/worlds/wargroove2/Items.py
+++ b/worlds/wargroove2/Items.py
@@ -1,5 +1,5 @@
 from BaseClasses import Item, ItemClassification
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, Set, List, NamedTuple, Optional
 
 PROGRESSION = ItemClassification.progression
 PROGRESSION_SKIP_BALANCING = ItemClassification.progression_skip_balancing
@@ -71,10 +71,24 @@ item_table: Dict[str, ItemData] = {
 }
 
 item_id_name: Dict[int, str] = {}
+item_name_groups: Dict[str, Set[str]] = {}
 for name in item_table.keys():
     id = item_table[name].code
     if id is not None:
         item_id_name[id] = name
+
+    group = item_table[name].type
+    if not group or id is None:
+        continue
+    if group == "Trigger":
+        # Split triggers since they serve very different purposes.
+        if "Final" in name:
+            group = "Final"
+        else:
+            group = "Event"
+    if group not in item_name_groups:
+        item_name_groups[group] = set()
+    item_name_groups[group].add(name)
 
 
 class CommanderData(NamedTuple):

--- a/worlds/wargroove2/__init__.py
+++ b/worlds/wargroove2/__init__.py
@@ -102,6 +102,7 @@ class Wargroove2World(World):
 
     item_name_to_id = {name: data.code for name, data in item_table.items() if data.code is not None}
     location_name_to_id = {name: code for name, code in location_table.items() if code is not None}
+    item_name_groups = Items.item_name_groups
 
     def generate_early(self) -> None:
         early_level_slots = 4


### PR DESCRIPTION
## What is this fixing or adding?
This adds item groups to Wargroove 2. Item groups have two main purposes:
- Allowing the player to hint the item group, which will reveal the location of the logically earliest item in the group.
- An easy way to refer to all items in the group, allowing for cleaner and easier to read YAMLs

The item groups added are units (named "Unit"), event items that don't unlock final missions (named "Event"), event items that unlock final missions (named "Final"), factions (named "Faction"), and filler boosts (named "Boost").

## How was this tested?
I generated a test seed, set hint cost to 0, and then hinted each item group. I verified that the hinted items matched the expected contents of each item group.

